### PR TITLE
Enable to set *fontoptions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,8 @@ Version: 0.5.0
 Authors@R: c(
     person("Frederik", "Aust", email = "frederik.aust@uni-koeln.de", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-4900-788X")),
     person("Lisa", "Spitzer", email = "lisa.spitzer95@yahoo.de", role = "aut"),
-    person("Jeffrey R.", "Stevens", email = "jeffrey.r.stevens@gmail.com", role = "ctb", comment = c(ORCID = "0000-0003-2375-1360"))
+    person("Jeffrey R.", "Stevens", email = "jeffrey.r.stevens@gmail.com", role = "ctb", comment = c(ORCID = "0000-0003-2375-1360")),
+    person("Masataka", "Ogawa", email = "ogawa@phiz.c.u-tokyo.ac.jp", role = "ctb")
   )
 Description: Provides a collection of templates to author preregistration documents for scientific studies in PDF format.
 URL: https://github.com/crsh/prereg

--- a/inst/rmd/prereg_form.tex
+++ b/inst/rmd/prereg_form.tex
@@ -243,13 +243,6 @@ $endif$
 \def\changemargin#1#2{\list{}{\rightmargin#2\leftmargin#1}\item[]}
 \let\endchangemargin=\endlist
 
-% Create subtitle command for use in maketitle
-\newcommand{\subtitle}[1]{
-\posttitle{
-\begin{center}\large#1\end{center}
-}
-}
-
 \setlength{\droptitle}{-2em}
 $if(title)$
 \title{$title$}
@@ -261,6 +254,13 @@ $else$
 \posttitle{}
 $endif$
 $if(subtitle)$
+% Create subtitle command for use in maketitle
+\usepackage{etoolbox}
+\makeatletter
+\providecommand{\subtitle}[1]{% add subtitle to \maketitle
+  \apptocmd{\@title}{\par {\large #1 \par}}{}{}
+}
+\makeatother
 \subtitle{$subtitle$}
 $endif$
 $if(author)$

--- a/inst/rmd/prereg_form.tex
+++ b/inst/rmd/prereg_form.tex
@@ -352,7 +352,8 @@ $if(lof)$
 \listoffigures
 $endif$
 
-\newcommand\Question[2]{%
+\NewCommandCopy{\oldQuestion}{\Question}
+\renewcommand\Question[2]{%
    \leavevmode\par
    \stepcounter{question}
    \noindent

--- a/inst/rmd/prereg_form.tex
+++ b/inst/rmd/prereg_form.tex
@@ -1,44 +1,101 @@
+% Options for packages loaded elsewhere
+\PassOptionsToPackage{unicode$for(hyperrefoptions)$,$hyperrefoptions$$endfor$}{hyperref}
+\PassOptionsToPackage{hyphens}{url}
+$if(colorlinks)$
+\PassOptionsToPackage{dvipsnames,svgnames,x11names}{xcolor}
+$endif$
+$if(CJKmainfont)$
+\PassOptionsToPackage{space}{xeCJK}
+$endif$
+
 \documentclass[$if(fontsize)$$fontsize$,$endif$$if(lang)$$lang$,$endif$$if(papersize)$$papersize$,$endif$$for(classoption)$$classoption$$sep$,$endfor$]{$documentclass$}
+\usepackage{amsmath,amssymb}
 $if(fontfamily)$
-  \usepackage{$fontfamily$}
+\usepackage[$for(fontfamilyoptions)$$fontfamilyoptions$$sep$,$endfor$]{$fontfamily$}
 $else$
-    \usepackage{lmodern}
+\usepackage{lmodern}
 $endif$
-  $if(linestretch)$
-  \usepackage{setspace}
-\setstretch{$linestretch$}
+$if(linestretch)$
+\usepackage{setspace}
 $endif$
-  \usepackage{amssymb,amsmath}
-\usepackage{ifxetex,ifluatex}
-\usepackage{fixltx2e} % provides \textsubscript
-\ifnum 0\ifxetex 1\fi\ifluatex 1\fi=0 % if pdftex
-\usepackage[T1]{fontenc}
-\usepackage[utf8]{inputenc}
-$if(euro)$
-  \usepackage{eurosym}
-$endif$
-  \else % if luatex or xelatex
-\ifxetex
-\usepackage{mathspec}
-\usepackage{xltxtra,xunicode}
-\else
-  \usepackage{fontspec}
-\fi
-\defaultfontfeatures{Mapping=tex-text,Scale=MatchLowercase}
-\newcommand{\euro}{€}
-$if(mainfont)$
-  \setmainfont{$mainfont$}
-$endif$
-  $if(sansfont)$
-  \setsansfont{$sansfont$}
-$endif$
-  $if(monofont)$
-  \setmonofont[Mapping=tex-ansi]{$monofont$}
-$endif$
-  $if(mathfont)$
-  \setmathfont(Digits,Latin,Greek){$mathfont$}
-$endif$
+\usepackage{iftex}
+\ifPDFTeX
+  \usepackage[$if(fontenc)$$fontenc$$else$T1$endif$]{fontenc}
+  \usepackage[utf8]{inputenc}
+  \usepackage{textcomp} % provide euro and other symbols
+\else % if luatex or xetex
+$if(mathspec)$
+  \ifXeTeX
+    \usepackage{mathspec}
+  \else
+    \usepackage{unicode-math}
   \fi
+$else$
+  \usepackage{unicode-math}
+$endif$
+  \defaultfontfeatures{Scale=MatchLowercase}
+  \defaultfontfeatures[\rmfamily]{Ligatures=TeX,Scale=1}
+$if(mainfont)$
+  \setmainfont[$for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$]{$mainfont$}
+$endif$
+$if(sansfont)$
+  \setsansfont[$for(sansfontoptions)$$sansfontoptions$$sep$,$endfor$]{$sansfont$}
+$endif$
+$if(monofont)$
+  \setmonofont[$for(monofontoptions)$$monofontoptions$$sep$,$endfor$]{$monofont$}
+$endif$
+$for(fontfamilies)$
+  \newfontfamily{$fontfamilies.name$}[$for(fontfamilies.options)$$fontfamilies.options$$sep$,$endfor$]{$fontfamilies.font$}
+$endfor$
+$if(mathfont)$
+$if(mathspec)$
+  \ifXeTeX
+    \setmathfont(Digits,Latin,Greek)[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \else
+    \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+  \fi
+$else$
+  \setmathfont[$for(mathfontoptions)$$mathfontoptions$$sep$,$endfor$]{$mathfont$}
+$endif$
+$endif$
+$if(CJKmainfont)$
+  \ifXeTeX
+    \usepackage{xeCJK}
+    \setCJKmainfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+  \fi
+$endif$
+$if(luatexjapresetoptions)$
+  \ifLuaTeX
+    \usepackage[$for(luatexjapresetoptions)$$luatexjapresetoptions$$sep$,$endfor$]{luatexja-preset}
+  \fi
+$endif$
+$if(CJKmainfont)$
+  \ifLuaTeX
+    \usepackage[$for(luatexjafontspecoptions)$$luatexjafontspecoptions$$sep$,$endfor$]{luatexja-fontspec}
+    \setmainjfont[$for(CJKoptions)$$CJKoptions$$sep$,$endfor$]{$CJKmainfont$}
+  \fi
+$endif$
+\fi
+$if(zero-width-non-joiner)$
+%% Support for zero-width non-joiner characters.
+\makeatletter
+\def\zerowidthnonjoiner{%
+  % Prevent ligatures and adjust kerning, but still support hyphenating.
+  \texorpdfstring{%
+    \textormath{\nobreak\discretionary{-}{}{\kern.03em}%
+      \ifvmode\else\nobreak\hskip\z@skip\fi}{}%
+  }{}%
+}
+\makeatother
+\ifPDFTeX
+  \DeclareUnicodeCharacter{200C}{\zerowidthnonjoiner}
+\else
+  \catcode`^^^^200c=\active
+  \protected\def ^^^^200c{\zerowidthnonjoiner}
+\fi
+%% End of ZWNJ support
+$endif$
+
 % use upquote if available, for straight quotes in verbatim environments
 \IfFileExists{upquote.sty}{\usepackage{upquote}}{}
 % use microtype if available


### PR DESCRIPTION
I ported font options from pandoc's latex template [default.latex](https://github.com/jgm/pandoc-templates/blob/master/default.latex) to `prereg_form.tex`, and the following font options are now settable:

- `mainfontoptions`
- `sansfontoptions`
- `monofontoptions`
- `mathfontoptions`
- `CJKfontoptions`

This modification also imports `unicode-math` to set math fonts. Since [`unicode-math`'s `\Question`](http://mirrors.ctan.org/macros/unicodetex/latex/unicode-math/unimath-symbols.pdf#page=24) crashed with prereg's `\Question`, I made `\NewCommandCopy` save `\Question` of unicode-math and redefined the command for prereg's `\Question` using `\renewcommand`.
