### PR TITLE
Fixed typo (iterval -> interval) and enabled `numbersection` option

### DIFF
--- a/inst/rmarkdown/templates/brandt_prereg/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/brandt_prereg/skeleton/skeleton.Rmd
@@ -38,7 +38,7 @@ Enter your response here.
 Enter your response here.
 
 
-## Confidence iterval 
+## Confidence interval 
 <!-- The confidence interval of the original effect is -->
 
 Enter your response here.

--- a/inst/rmd/prereg_form.tex
+++ b/inst/rmd/prereg_form.tex
@@ -308,7 +308,11 @@ $endfor$
 
 % Title settings
 \usepackage{titlesec}
+$if(numbersections)$
+\titleformat{\section}[hang]{\bfseries\Large}{\thesection}{0.5em}{}[]
+$else$
 \titleformat{\section}[display]{\bfseries\Large}{\thesection}{}{}[]
+$endif$
 \titlespacing{\section}{0pc}{*3}{*1.5}
 \titleformat{\subsection}[leftmargin]{\titlerule\bfseries\filleft}{\thesubsection}{.5em}{}
 \titlespacing{\subsection}{8pc}{5ex plus .1ex minus .2ex}{1.5pc}


### PR DESCRIPTION
I corrected a typo (iterval -> interval) in `inst/rmarkdown/templates/brandt_prereg/skeleton/skeleton.Rmd`. Also, I modified `inst/rmd/prereg_form.tex` so that we can render `prereg::*_prereg` with the option `number_sections: true`.