### PR TITLE
Add internal formatting rules for comment blocks in lint-prereg-skeleton skill

### DIFF
--- a/.github/skills/lint-prereg-skeleton/SKILL.md
+++ b/.github/skills/lint-prereg-skeleton/SKILL.md
@@ -35,9 +35,10 @@ Run `.github/skills/lint-prereg-skeleton/lint_skeleton.R` on the target file(s):
 Rscript .github/skills/lint-prereg-skeleton/lint_skeleton.R <path/to/skeleton.Rmd>
 ```
 
-The script automates Rules 1–11 (see [formatting-rules.md](./references/formatting-rules.md)):
+The script automates Rules 1–11 and 13–15 (see [formatting-rules.md](./references/formatting-rules.md)):
 trailing whitespace, comment delimiter spacing, blank-line removal between headings and comments,
-prompt-text normalisation, section spacing, `\newpage` padding, bullet style, and sentence-case headings.
+prompt-text normalisation, section spacing, `\newpage` padding, bullet style, sentence-case headings,
+and comment block internal formatting (paragraph joining, blank-line separation, leading whitespace removal).
 
 ### 3. Verify script output
 
@@ -52,6 +53,7 @@ Review the diff produced by the script. Check that every automated rule has been
 Work through the rules the script does **not** cover, and fix any edge cases the script missed:
 
 - **Rule 12 — Spelling and grammar**: fix clear spelling errors and obvious grammar errors in headings and comment text. Preserve original wording and intent; do not paraphrase. Leave examples, R code, LaTeX, and YAML untouched.
+- **Rule 16 — Unlabeled bullet lists**: Rules 13–15 join unlabeled items into paragraphs. After the script runs, inspect joined paragraphs to identify hidden lists and add `- ` markers manually.
 - **Missing prompts**: add `Enter your response here.` to any Type A section that lacks one.
 - **Encoding issues**: correct any garbled characters (e.g. `Í` → `'`).
 

--- a/.github/skills/lint-prereg-skeleton/lint_skeleton.R
+++ b/.github/skills/lint-prereg-skeleton/lint_skeleton.R
@@ -20,11 +20,18 @@
 #  10. Bullet style: * -> - everywhere
 #  11. Sentence case headings (with acronym/proper-noun whitelist)
 #      + collapse 3+ consecutive blank lines to 2
+#  13. Paragraphs on single lines: join wrapped continuation lines within comment blocks
+#  14. Blank lines between paragraphs and lists within comment blocks;
+#      known section starters (Example:, More information:, Note:, etc.)
+#      are always preceded by a blank line
+#  15. No leading whitespace on non-list lines within comment blocks
 #
 # NOT automated (require judgment):
 #   - Spelling/grammar fixes
 #   - Adding missing prompts to Type A sections
 #   - Encoding corruption fixes
+#   - Adding missing list markers (-) to unlabeled bullet items in comment blocks
+#     (Rules 13-15 will join unlabeled items into paragraphs; add markers manually)
 
 # ---------------------------------------------------------------------------
 # Acronyms and proper nouns to preserve in headings (sentence-case pass)
@@ -404,6 +411,206 @@ rule_collapse_blanks <- function(lines, yaml_end, refs_start) {
 }
 
 # ---------------------------------------------------------------------------
+# Helpers for comment block internals (Rules 13–15)
+# ---------------------------------------------------------------------------
+
+# Regex for known section starters that open a new paragraph inside a comment.
+# Matches at the START of stripped content.  Colon or period, followed by a
+# space or end-of-string (handles "Example:" alone on a line as well as
+# "Example: text here").
+COMMENT_SECTION_RE <- paste0(
+  "^(Examples?( [0-9]+)?[.:](\\s|$))",
+  "|(^More information[.:](\\s|$))",
+  "|(^More info[.:](\\s|$))",
+  "|(^Note[.:](\\s|$))",
+  "|(^N\\.B\\.[.:](\\s|$))",
+  "|(^Warning[.:](\\s|$))"
+)
+
+# TRUE when a stripped line is a Markdown list item (numbered or bulleted)
+is_inner_list <- function(s) {
+  grepl("^\\s*\\d+\\.\\s", s, perl = TRUE) ||
+  grepl("^\\s*-\\s",        s, perl = TRUE)
+}
+
+# TRUE when a stripped line is a known section starter inside a comment
+is_section_start <- function(s) {
+  grepl(COMMENT_SECTION_RE, s, perl = TRUE)
+}
+
+# TRUE when a line ends with sentence-ending punctuation (.!?)
+ends_sentence <- function(s) {
+  if (!grepl("[.!?]\\s*$", s, perl = TRUE)) return(FALSE)
+  # Exclude common abbreviations ending with a period (not sentence enders)
+  abbrev_re <- "\\b(vs|e\\.g|i\\.e|etc|cf|al|fig|ref|no|vol|pp|ed|eds|ch|approx|incl|excl|dept|est|min|max|avg|std)\\.$"
+  !grepl(abbrev_re, trimws(s), ignore.case = TRUE, perl = TRUE)
+}
+
+# ---------------------------------------------------------------------------
+# Rules 13–15: reformat comment block internals
+#
+#   Rule 13 – join wrapped paragraph continuation lines into single lines.
+#             A line is a continuation when (a) the previous output line ends
+#             without sentence-ending punctuation AND (b) the current line
+#             starts with a lower-case letter.
+#   Rule 14 – separate paragraphs and lists with blank lines:
+#             • blank line before every known section starter
+#             • blank line before a list that follows non-list content
+#             • blank line before a new text paragraph that did not join
+#   Rule 15 – strip leading whitespace from non-list lines inside comments
+# ---------------------------------------------------------------------------
+
+rule_reformat_comment_internals <- function(lines, yaml_end, refs_start) {
+  body_start <- yaml_end + 1L
+  body_end   <- refs_start - 1L
+
+  out     <- lines[seq_len(yaml_end)]
+  i       <- body_start
+  in_cmt  <- FALSE
+  in_code <- FALSE
+
+  while (i <= body_end) {
+    l      <- lines[i]
+    l_trim <- trimws(l)
+
+    # Code fences: pass through untouched
+    if (startsWith(l, "```")) {
+      in_code <- !in_code
+      out <- c(out, l)
+      i   <- i + 1L
+      next
+    }
+    if (in_code) {
+      out <- c(out, l)
+      i   <- i + 1L
+      next
+    }
+
+    # Detect comment open / close on this line
+    opens  <- !in_cmt && grepl("<!--", l, fixed = TRUE)
+    if (opens) in_cmt <- TRUE
+    closes <- in_cmt && endsWith(l_trim, "-->")
+
+    # Outside any comment: pass through unchanged
+    if (!in_cmt) {
+      out <- c(out, l)
+      i   <- i + 1L
+      next
+    }
+
+    is_opener <- opens   # this line opened the comment
+
+    # Strip closing --> for content analysis (will be re-added)
+    content_raw <- if (closes) sub("\\s*-->\\s*$", "", l) else l
+
+    # Strip opening <!-- to isolate text content
+    if (is_opener) {
+      if (trimws(content_raw) %in% c("<!--", "")) {
+        # Standalone opener with no content on this line
+        out <- c(out, "<!--")
+        if (closes) in_cmt <- FALSE
+        i <- i + 1L
+        next
+      }
+      content <- trimws(sub("^\\s*<!--\\s*", "", content_raw))
+    } else {
+      content <- trimws(content_raw)
+    }
+
+    # Blank line within comment: preserve as-is
+    if (content == "") {
+      if (closes) {
+        # Safety: blank content before -->  →  attach --> to previous line
+        if (length(out) > 0 && trimws(out[length(out)]) != "") {
+          out[length(out)] <- paste0(out[length(out)], " -->")
+        } else {
+          out <- c(out, "-->")
+        }
+        in_cmt <- FALSE
+      } else {
+        out <- c(out, "")
+      }
+      i <- i + 1L
+      next
+    }
+
+    is_list    <- is_inner_list(content)
+    is_section <- !is_list && is_section_start(content)
+
+    # Inspect the previous output line for join / spacing decisions
+    prev          <- if (length(out) > 0) out[length(out)] else ""
+    prev_trim     <- trimws(prev)
+    prev_is_blank <- prev_trim == ""
+    prev_is_only  <- prev_trim == "<!--"   # standalone opener, no content
+
+    # Core content of previous line (strip delimiters for comparisons)
+    prev_core    <- trimws(sub("\\s*-->\\s*$", "",
+                               sub("^<!--\\s*", "", prev_trim)))
+    prev_is_list <- is_inner_list(prev_core)
+
+    # ---- Decide what to do with this line ----
+
+    if (is_section) {
+      # Rule 14: ensure a blank line precedes section starters
+      if (!prev_is_blank && !prev_is_only) {
+        out <- c(out, "")
+      }
+      line_out <- content
+      if (is_opener) line_out <- paste0("<!-- ", line_out)
+      if (closes)    line_out <- paste0(line_out, " -->")
+      out <- c(out, line_out)
+
+    } else {
+      # Rule 13: can we join this line to the previous output line?
+      # Conditions: not the opener, not a list item, previous is non-blank
+      # and not a standalone <!--, previous content does NOT end with
+      # sentence-ending punctuation, and this line starts with a lower-case
+      # letter (unambiguous mid-sentence continuation).
+      can_join <- !is_opener &&
+                  !is_list &&
+                  !prev_is_blank &&
+                  !prev_is_only &&
+                  !prev_is_list &&
+                  !ends_sentence(prev_core) &&
+                  grepl("^[a-z0-9(]", content, perl = TRUE)
+
+      if (can_join) {
+        # Attach content to the tail of the previous output line,
+        # moving any existing --> suffix to the new end.
+        prev_has_close <- endsWith(prev_trim, "-->")
+        base <- if (prev_has_close) trimws(sub("\\s*-->\\s*$", "", prev))
+                else prev
+        joined <- paste0(base, " ", content)
+        if (closes || prev_has_close) joined <- paste0(joined, " -->")
+        out[length(out)] <- joined
+
+      } else {
+        # Rule 14: add blank separator before this new "chunk" if needed
+        if (!prev_is_blank && !prev_is_only) {
+          if (is_list) {
+            # Blank before a list item that follows non-list content
+            if (!prev_is_list) out <- c(out, "")
+          } else if (!is_opener) {
+            # Blank before a new text paragraph
+            out <- c(out, "")
+          }
+        }
+        # Rule 15: emit line without leading whitespace
+        line_out <- content
+        if (is_opener) line_out <- paste0("<!-- ", line_out)
+        if (closes)    line_out <- paste0(line_out, " -->")
+        out <- c(out, line_out)
+      }
+    }
+
+    if (closes) in_cmt <- FALSE
+    i <- i + 1L
+  }
+
+  c(out, lines[refs_start:length(lines)])
+}
+
+# ---------------------------------------------------------------------------
 # Main processing pipeline
 # ---------------------------------------------------------------------------
 
@@ -436,6 +643,13 @@ process_file <- function(path) {
   refs_start <- find_refs_start(lines)
 
   lines <- rule_prompt_text(lines, yaml_end, refs_start)
+
+  # Rules 13-15: reformat comment block internals
+  lines <- rule_reformat_comment_internals(lines, yaml_end, refs_start)
+
+  yaml_end   <- find_yaml_end(lines)
+  refs_start <- find_refs_start(lines)
+
   lines <- rule_section_spacing(lines, yaml_end, refs_start)
 
   yaml_end   <- find_yaml_end(lines)

--- a/.github/skills/lint-prereg-skeleton/references/formatting-rules.md
+++ b/.github/skills/lint-prereg-skeleton/references/formatting-rules.md
@@ -423,6 +423,107 @@ question. -->
 
 ---
 
+## Rule 13 — Paragraphs on single lines inside comment blocks
+
+Each paragraph inside a comment block must be a single, unbroken line. Lines that are
+clearly continuations of the previous line (lowercase, digit, or `(` start; no sentence
+ending) must be joined onto the previous line with a single space.
+
+```
+# ✗ Wrong — paragraph split across lines
+<!-- We will test whether the mismatch negativity (MMN) is modulated by pitch
+differences differently in people with and without musical training. -->
+
+# ✓ Correct
+<!-- We will test whether the mismatch negativity (MMN) is modulated by pitch differences differently in people with and without musical training. -->
+```
+
+Note: Lines beginning with an uppercase letter are treated as new paragraphs, not
+continuations. Common abbreviations ending with `.` (e.g., `vs.`, `e.g.`, `i.e.`) are
+not treated as sentence endings and do not prevent joining.
+
+---
+
+## Rule 14 — Blank lines between paragraphs and lists inside comment blocks
+
+Inside comment blocks, paragraphs and list blocks must be separated by blank lines.
+Known section starters (`Example:`, `More information:`, `More info:`, `Note:`, `N.B.:`,
+`Warning:`) always begin on their own line, preceded by a blank line.
+
+```
+# ✗ Wrong — no blank line before list, no blank line before section starter
+<!-- Describe the variables:
+- Independent variable.
+- Dependent variable.
+Note: Provide precise definitions. -->
+
+# ✓ Correct
+<!-- Describe the variables:
+
+- Independent variable.
+- Dependent variable.
+
+Note: Provide precise definitions. -->
+```
+
+```
+# ✗ Wrong — example inline with instruction
+<!-- Describe the procedure. Example: We will present tones in an oddball paradigm. -->
+
+# ✓ Correct
+<!-- Describe the procedure.
+
+Example: We will present tones in an oddball paradigm. -->
+```
+
+---
+
+## Rule 15 — No leading whitespace on paragraph lines inside comment blocks
+
+Regular text paragraphs (non-list lines) inside comment blocks must not have leading
+whitespace. Only nested list items may be indented.
+
+```
+# ✗ Wrong — indented paragraph text
+<!--
+  Describe the procedure.
+  Example: We will present tones. -->
+
+# ✓ Correct
+<!-- Describe the procedure.
+
+Example: We will present tones. -->
+```
+
+---
+
+## Rule 16 — Unlabeled bullet lists must use `-` markers (manual)
+
+When a comment block contains a list of items that are formatted as a paragraph (no `-`
+markers), the items must be reformatted as a proper bullet list with `- ` markers. This
+requires manual judgment to identify what constitutes a list.
+
+Rules 13–15 will join unlabeled items into a single paragraph. After the script runs,
+inspect joined paragraphs to determine if they represent a list, then add `-` markers
+manually.
+
+```
+# ✗ Wrong — list items run together as paragraph text
+<!-- Please report at least the following properties: filter type, e.g., FIR,
+IIR, Butterworth filter order, e.g., 5th order filter cut-off frequency,
+e.g., 40 Hz filter roll-off, e.g., 12 dB/oct -->
+
+# ✓ Correct — each item on its own line with - marker
+<!-- Please report at least the following properties:
+
+- filter type, e.g., FIR, IIR, Butterworth
+- filter order, e.g., 5th order
+- filter cut-off frequency, e.g., 40 Hz
+- filter roll-off, e.g., 12 dB/oct -->
+```
+
+---
+
 ## Summary table
 
 | Location | Rule |
@@ -445,6 +546,10 @@ question. -->
 | `###` heading | Sub-question; when `##` → `###`, rules apply to `###` |
 | Heading text | Sentence case; preserve acronyms, proper nouns, alphanumeric prefixes |
 | Spelling & grammar | Fix clear errors in headings and comments; preserve wording and intent |
+| Comment paragraphs | Each paragraph on a single line; join wrapped continuations |
+| Comment paragraph/list separation | Blank lines between paragraphs and lists; section starters on own line |
+| Comment paragraph indentation | No leading whitespace on non-list lines |
+| Unlabeled bullet items | Add `- ` markers manually after script run |
 
 ---
 

--- a/inst/rmarkdown/templates/eeg_erg_prereg/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/eeg_erg_prereg/skeleton/skeleton.Rmd
@@ -17,26 +17,32 @@ output: prereg::prereg_pdf
 ---
 
 <!-- Introduction
+
 This preregistration template guides researchers who wish to preregister their EEG projects, more specifically studies investigating event-related potentials (ERPs) in the sensor space. We invite researchers to use and/or adapt the template to other forms of EEG analysis (e.g., source space, time-frequency, steady-state).
+
 We emphasize that all examples in this template are non-exhaustive and are aimed to provide guidance on how to transparently preregister a study’s analysis plan. Besides descriptions for individual items, we provide examples for better illustration only. With these examples we do not intend to provide researchers with guidance about choosing specific preprocessing and analysis steps.
+
 This template accompanies the paper “Making ERP research more transparent: Guidelines for preregistration” (Paul et al., 2021). The paper describes common ways to preprocess and analyze ERP data, discusses the (often arbitrary) choices that lead to a “garden of forking paths”, and highlights preregistration as a viable solution. It also offers more information and additional examples. -->
 
 
 # Study information
 ## Description
-<!-- Please give a brief description of your study, including some background, the
-purpose of the study (e.g., whether it is a replication), or broad research questions.
- Example: We will test whether the mismatch negativity (MMN) is modulated by pitch differences differently in people with and without musical training. We will present a group of musicians and a group of non-musicians with tones in an oddball paradigm. The difference between the standard and the deviant tone will be either small (4 Hz) or large (8 Hz). We collect EEG data as well as behavioral accuracy in detecting the oddball as measured by a button-press.
- More info: The description should be no longer than the length of an abstract. It can give some context for the proposed study, but great detail is not needed here for your preregistration. -->
+<!-- Please give a brief description of your study, including some background, the purpose of the study (e.g., whether it is a replication), or broad research questions.
+
+Example: We will test whether the mismatch negativity (MMN) is modulated by pitch differences differently in people with and without musical training. We will present a group of musicians and a group of non-musicians with tones in an oddball paradigm. The difference between the standard and the deviant tone will be either small (4 Hz) or large (8 Hz). We collect EEG data as well as behavioral accuracy in detecting the oddball as measured by a button-press.
+
+More info: The description should be no longer than the length of an abstract. It can give some context for the proposed study, but great detail is not needed here for your preregistration. -->
 
 Enter your response here.
 
 
 ## Hypotheses*
-<!-- List specific, concise, and testable hypotheses. Please state if the hypotheses
-are directional or non-directional. If directional, state the direction. A predicted effect size is also appropriate here. If a specific interaction or moderation is important to your research, you can list that as a separate hypothesis. State the specific ERP component for which an experimental manipulation is (or is not) expected.
- Example:
+<!-- List specific, concise, and testable hypotheses. Please state if the hypotheses are directional or non-directional. If directional, state the direction. A predicted effect size is also appropriate here. If a specific interaction or moderation is important to your research, you can list that as a separate hypothesis. State the specific ERP component for which an experimental manipulation is (or is not) expected.
+
+Example:
+
 H1 (directional). We predict that, behaviourally, people with musical training would be more accurate at discriminating small pitch differences compared to those without musical training, as evidenced by statistically more accurate performance in the behavioral discrimination task for the small pitch difference among musically trained individuals.
+
 H2 (directional). We predict that, at the electrophysiological level, people with musical training would show a stronger discrimination response to both small and large pitch differences compared to people without musical training. This would be reflected in a larger mean amplitude of the MMN to both the smaller and the larger pitch difference for the musically trained individuals. -->
 
 Enter your response here.
@@ -48,16 +54,19 @@ Enter your response here.
 
 ## Stimuli*
 <!-- Describe the stimuli used in the experiment.
- Example: The pitch difference for the small difference is 4 Hz (standard 400
-Hz, deviant 404 Hz), and for the large difference is 8 Hz (standard 400 Hz, deviant 408 Hz). There will be 300 trials per block, 80% of which are standards (N = 240; 400 Hz), and 20% are deviants (N = 60, either 404 Hz or 408 Hz). The stimuli will be created as pure sine tones (mono, sampling frequency of 44100 Hz, amplitude of 0.2 Pa and Fade-in and fade-out durations of 0.01 sec). -->
+
+Example: The pitch difference for the small difference is 4 Hz (standard 400 Hz, deviant 404 Hz), and for the large difference is 8 Hz (standard 400 Hz, deviant 408 Hz). There will be 300 trials per block, 80% of which are standards (N = 240; 400 Hz), and 20% are deviants (N = 60, either 404 Hz or 408 Hz). The stimuli will be created as pure sine tones (mono, sampling frequency of 44100 Hz, amplitude of 0.2 Pa and Fade-in and fade-out durations of 0.01 sec). -->
 
 Enter your response here.
 
 
 ## Study design*
 <!-- Describe your study design. Is it a between-subject, within-subject, or mixed design?
- Example: We will employ a mixed 2x2 design, with one between-subject factor musical training (two levels: musicians - non-musicians) and one within-subject factor pitch difference (two levels: small difference, large difference).
+
+Example: We will employ a mixed 2x2 design, with one between-subject factor musical training (two levels: musicians - non-musicians) and one within-subject factor pitch difference (two levels: small difference, large difference).
+
 Describe the experimental design. Consider adding the following information:
+
 - Stimulus presentation duration
 - Inter-stimulus interval
 - Trial duration
@@ -67,24 +76,25 @@ Describe the experimental design. Consider adding the following information:
 - Participant’s task
 - Duration of the study
 - Response window
- Example. Stimuli will be presented for 400 ms, with an ISI of 500 ms. Participants will be presented with 4 blocks (two with small pitch difference, two with large pitch difference) of 300 trials each, separated by short self-paced pauses. The total duration of the experiment will be about 20 minutes. Participants will be instructed to press the spacebar when they detect the deviant (i.e., stimulus that has a higher pitch).
+
+Example. Stimuli will be presented for 400 ms, with an ISI of 500 ms. Participants will be presented with 4 blocks (two with small pitch difference, two with large pitch difference) of 300 trials each, separated by short self-paced pauses. The total duration of the experiment will be about 20 minutes. Participants will be instructed to press the spacebar when they detect the deviant (i.e., stimulus that has a higher pitch).
+
 More info: This question has a variety of possible answers. The key is for a researcher to be as detailed as is necessary given the specifics of their design. Be careful to determine if every parameter has been specified in the description of the study design. There may be some overlap between this question and the following questions. That is OK, as long as sufficient detail is given in one of the areas to provide all of the requested information. For example, if the study design describes a complete factorial, 2x2 design and the treatments and levels are specified previously, you do not have to repeat that information. -->
 
 Enter your response here.
 
 
 ## Randomization*
-<!-- If you are doing a randomized study, how will you randomize, and at what
-level? What kind of counterbalancing will you use?
-Example: We will pseudo-randomize the stimuli such that there will be at
-least 3 consecutive standards between each deviant. Participants’ group assignment is based on pre-set musicality criteria and therefore cannot be randomized. Non-musicians will be age-matched to musicians. Block order will be counterbalanced: within each group, participants assigned with an odd number will be presented with the small difference block first, whereas participants assigned with an even number will be presented with the large difference block first. -->
+<!-- If you are doing a randomized study, how will you randomize, and at what level? What kind of counterbalancing will you use?
+
+Example: We will pseudo-randomize the stimuli such that there will be at least 3 consecutive standards between each deviant. Participants’ group assignment is based on pre-set musicality criteria and therefore cannot be randomized. Non-musicians will be age-matched to musicians. Block order will be counterbalanced: within each group, participants assigned with an odd number will be presented with the small difference block first, whereas participants assigned with an even number will be presented with the large difference block first. -->
 
 Enter your response here.
 
 
 ## Blinding
-<!-- Blinding describes who is aware of the experimental manipulations within a
-study. You can specify whether the study was blind for subjects, experimenters or double blind. You can also specify whether the analysis was performed in a blind way.
+<!-- Blinding describes who is aware of the experimental manipulations within a study. You can specify whether the study was blind for subjects, experimenters or double blind. You can also specify whether the analysis was performed in a blind way.
+
 Example: Group assignment is based on pre-set musicality criteria, and will not be blinded for the experimenter. The experimenter will not be blinded to block order either, since this is a perceivable pitch difference (at least for a trained listener). Preprocessing will be blinded, that is, the researcher performing the preprocessing will not be aware of the participant’s group, or of the pitch difference of the block. -->
 
 Enter your response here.
@@ -92,9 +102,11 @@ Enter your response here.
 
 ## Manipulation check
 <!-- Describe whether you are going to do any manipulation checks
-Example: We will check whether the participants are, independent of our
-manipulation, able to hear the tones. Therefore, we will assess whether all individual participants show a P100 averaged across conditions.
+
+Example: We will check whether the participants are, independent of our manipulation, able to hear the tones. Therefore, we will assess whether all individual participants show a P100 averaged across conditions.
+
 Sampling Plan
+
 In this section, please describe how you plan to collect samples, as well as the number of samples you plan to collect and your rationale for this decision. Please keep in mind that the data described in this section should be the actual data used for analysis, so if you are using a subset of a larger dataset, please describe the subset that will actually be used in your study. -->
 
 Enter your response here.
@@ -116,64 +128,57 @@ If this is the case, please indicate in your final paper that this is a preregis
 
 
 ## Explanation of existing data
-<!-- If you indicate that you will be using some data that already exists, please
-describe the steps you have taken to assure that you are unaware of any patterns or summary statistics in the data. This may include an explanation of how access to the data has been limited, who has observed the data, or how you have avoided observing any analysis of the existing data you will use in your study. -->
+<!-- If you indicate that you will be using some data that already exists, please describe the steps you have taken to assure that you are unaware of any patterns or summary statistics in the data. This may include an explanation of how access to the data has been limited, who has observed the data, or how you have avoided observing any analysis of the existing data you will use in your study. -->
 
 Enter your response here.
 
 
 ## Participant recruitment procedure
-<!-- Please describe the process by which you will collect (or have collected, see
-section 10) your data. If you are using human participants, this should include the sampling population, recruitment efforts, payment/reimbursement for participation, inclusion and exclusion criteria, and study timeline.
+<!-- Please describe the process by which you will collect (or have collected, see section 10) your data. If you are using human participants, this should include the sampling population, recruitment efforts, payment/reimbursement for participation, inclusion and exclusion criteria, and study timeline.
+
 Example: Participants will be recruited through advertisements at the local university and the conservatory. Participants will be paid €10 or receive course credit for their participation. Participants must be at least 18 years old, have normal hearing, with no history of neurological diseases. We will exclude participants that speak a tone language as L1/L2 (acquired before the age of 12). Participants will be considered musicians if they have received at least 12 years of formal music training. Participants will be considered non-musicians if they have never had any formal music training, except for group lessons in primary school.
+
 More information: The answer to this question requires a specific set of instructions so that another person could replicate the data collection procedures and recreate the study population as closely as possible. If the study population cannot be reproduced (e.g., patients with rare diseases, elite athletes), please clarify this here. -->
 
 Enter your response here.
 
 
 ## Sample size*
-<!-- Describe the sample size of your study. How many participants will be
-recruited?
-Example: Within the data collection phase of the study (three months), we
-aim to collect clean datasets from 80 participants (40 per group: with vs.
-without musical training).
-More information: For some studies, this will simply be the number of
-participants and/or the number of clusters. For others, this could be an expected range, minimum, or maximum number. -->
+<!-- Describe the sample size of your study. How many participants will be recruited?
+
+Example: Within the data collection phase of the study (three months), we aim to collect clean datasets from 80 participants (40 per group: with vs. without musical training).
+
+More information: For some studies, this will simply be the number of participants and/or the number of clusters. For others, this could be an expected range, minimum, or maximum number. -->
 
 Enter your response here.
 
 
 ## Sample size rationale*
-<!-- This gives you an opportunity to specifically state how the sample size will be
-determined. This could include a power analysis or an arbitrary constraint such as time, money, or personnel. If there is more than one hypothesis,
-choose the largest estimated sample size that is required from the power
-analyses corresponding to your hypotheses.
- Example: We used MOREpower software (Campbell & Thompson, 2012) to
-calculate the necessary sample size to detect an effect size of 𝞰2 = 0.15 with alpha level set at .05 for the interaction term (H1) in the 2 x 2 mixed ANOVA design to obtain .90 power. The target effect size is taken from a recent study by X et al. (2016) and accounted for a potential effect size inflation by taking 75% of the original effect size.
- More information: A wide range of possible answers is acceptable; remember that transparency is more important than principled justifications. If you state any reason for a sample size upfront, it is better than stating no reason and leaving the reader to “fill in the blanks.” Acceptable rationales include: a power analysis, an arbitrary number of subjects, or a number based on time or monetary constraints. For details, see Lakens (2022). -->
+<!-- This gives you an opportunity to specifically state how the sample size will be determined. This could include a power analysis or an arbitrary constraint such as time, money, or personnel. If there is more than one hypothesis, choose the largest estimated sample size that is required from the power analyses corresponding to your hypotheses.
+
+Example: We used MOREpower software (Campbell & Thompson, 2012) to calculate the necessary sample size to detect an effect size of 𝞰2 = 0.15 with alpha level set at .05 for the interaction term (H1) in the 2 x 2 mixed ANOVA design to obtain .90 power. The target effect size is taken from a recent study by X et al. (2016) and accounted for a potential effect size inflation by taking 75% of the original effect size.
+
+More information: A wide range of possible answers is acceptable; remember that transparency is more important than principled justifications. If you state any reason for a sample size upfront, it is better than stating no reason and leaving the reader to “fill in the blanks.” Acceptable rationales include: a power analysis, an arbitrary number of subjects, or a number based on time or monetary constraints. For details, see Lakens (2022). -->
 
 Enter your response here.
 
 
 ## Rationale for number of trials
-<!-- Provide a justification for how the number of trials was determined. This could
-be a power analysis, time and resource constraints or based on previous
-experiments in the literature.
- Example: Previous studies in the literature (e.g., X et al, 2016; X et al., 2012)
-have collected 600 trials per condition, and we have kept that consistent here.
- More information: A wide range of answers is acceptable, including a
-justification based on a power analysis, time constraints, or pilot studies. -->
+<!-- Provide a justification for how the number of trials was determined. This could be a power analysis, time and resource constraints or based on previous experiments in the literature.
+
+Example: Previous studies in the literature (e.g., X et al, 2016; X et al., 2012) have collected 600 trials per condition, and we have kept that consistent here.
+
+More information: A wide range of answers is acceptable, including a justification based on a power analysis, time constraints, or pilot studies. -->
 
 Enter your response here.
 
 
 ## Stopping rule
-<!-- If your data collection procedures do not give you full control over your exact
-sample size, specify how you will decide when to terminate your data
-collection.
- Example: If we have to exclude participants due to data quality issues
-(specify the criteria in the section “Data exclusion”), we will recruit additional participants to replace the excluded datasets. The minimum acceptable sample size within the scheduled data collection phase is 60 (30 per group). Due to budgetary constraints, we will terminate data collection after reaching a total of 100 participants.
- More information: You may specify a stopping rule based on p-values only in the specific case of sequential analyses with pre-specified checkpoints, alpha levels, and stopping rules. Unacceptable rationales include stopping based on p-values if checkpoints and stopping rules are not specified. -->
+<!-- If your data collection procedures do not give you full control over your exact sample size, specify how you will decide when to terminate your data collection.
+
+Example: If we have to exclude participants due to data quality issues (specify the criteria in the section “Data exclusion”), we will recruit additional participants to replace the excluded datasets. The minimum acceptable sample size within the scheduled data collection phase is 60 (30 per group). Due to budgetary constraints, we will terminate data collection after reaching a total of 100 participants.
+
+More information: You may specify a stopping rule based on p-values only in the specific case of sequential analyses with pre-specified checkpoints, alpha levels, and stopping rules. Unacceptable rationales include stopping based on p-values if checkpoints and stopping rules are not specified. -->
 
 Enter your response here.
 
@@ -184,30 +189,39 @@ Enter your response here.
 
 ## Manipulated variables*
 <!-- Describe all variables you plan to manipulate in your experimental paradigm.
- Example:
-Between-subject variable:
-Variable musical training, with two levels: musicians and non-musicians. Within-subject variable:
-Variable pitch difference, with two levels: 4 Hz (small difference) and 8 Hz (large difference).
- More information: For any experimental manipulation, you should give a precise definition of each manipulated variable. This must include a precise description of the levels at which each variable will be set, or a specific definition for each categorical treatment. For example, “loud” or “quiet,” should instead give either a precise decibel level or a means of recreating each level. 'Presence/absence' or 'positive/negative' is an acceptable description if the variable is precisely described. -->
+
+Example:
+
+Between-subject variable: Variable musical training, with two levels: musicians and non-musicians.
+
+Within-subject variable: Variable pitch difference, with two levels: 4 Hz (small difference) and 8 Hz (large difference).
+
+More information: For any experimental manipulation, you should give a precise definition of each manipulated variable. This must include a precise description of the levels at which each variable will be set, or a specific definition for each categorical treatment. For example, “loud” or “quiet,” should instead give either a precise decibel level or a means of recreating each level. 'Presence/absence' or 'positive/negative' is an acceptable description if the variable is precisely described. -->
 
 Enter your response here.
 
 
 ## Measured variables*
 <!-- Describe each variable that you will measure. This will include behavioral and EEG outcome measures, as well as any predictors or covariates that you will collect. In case of the EEG variables, please specify how you subselect your data in time and sensor space.
- Example:
-EEG outcome measure:
-The EEG outcome variable will be the difference wave, i.e., the mean amplitude in response to the deviant minus the mean amplitude in response to the previous standard, in a time-window of 50-250 ms at electrodes Fz, FCz, and Cz. Time window and electrodes were chosen based on recommendations by X et al. (2014).
-Behavioral outcome measure:
-Behavioral outcome will be measured by calculating the hit rate. An accurate response is defined as a button-press during the response window: between 100 ms after the start of the oddball until the start of the following standard.
- More information: As with the previous questions, the answers here must be precise. For example, 'MMN’ or ‘accuracy’ is too vague.
- More information on channel selection: Non-exhaustive list of examples:
+
+Example:
+
+EEG outcome measure: The EEG outcome variable will be the difference wave, i.e., the mean amplitude in response to the deviant minus the mean amplitude in response to the previous standard, in a time-window of 50-250 ms at electrodes Fz, FCz, and Cz. Time window and electrodes were chosen based on recommendations by X et al. (2014).
+
+Behavioral outcome measure: Behavioral outcome will be measured by calculating the hit rate. An accurate response is defined as a button-press during the response window: between 100 ms after the start of the oddball until the start of the following standard.
+
+More information: As with the previous questions, the answers here must be precise. For example, 'MMN’ or ‘accuracy’ is too vague.
+
+More information on channel selection: Non-exhaustive list of examples:
+
 - Exact a-priori ROI: "We will select electrodes FCz and Cz based on previous research (insert references to studies which use this combination of electrodes that were used to make the decision)"
 - Functional localizer: "In order to localize whether and where the MMN is reliably elicited, we will add a separate localizer task (discriminate between tones with a difference of 20 Hz), and select those electrodes that show a robust modulation to this difference."
 - We will consider a large candidate ROI over left motor cortex, including Cz, C1, C3, CPz, CP1, CP3, Pz, P1, P3, and select those electrodes that showed a robust modulation by left vs. right hand responses at p < .05, paired t-test"
 - Collapsed localizer: “We will select the 4 electrodes with the largest MMN between 50 and 250 ms on the grand average data”
 - No selection of channels necessary: e.g., mass-univariate, ICA/PCA, source-space, cluster-based permutation tests
- More information on time windows: Non-exhaustive list of examples:
+
+More information on time windows: Non-exhaustive list of examples:
+
 - Specified a-priori: “We will select a time-window 100-200 ms following stimulus onset”
 - Adaptive mean approach: “We will locate the peak amplitude within 200 ms from stimulus onset and average amplitude values for the 100 ms surrounding that peak for each participant individually” -->
 
@@ -215,8 +229,9 @@ Enter your response here.
 
 
 ## Indices
-<!--  If any measurements are going to be combined into an index (or even a mean), what measures will you use and how will they be combined? Include either a formula or a precise description of your method. If you are using a more complicated statistical method to combine measures (e.g., factor analysis, z-standardization within conditions/participants), you can note that here but describe the exact method in the analysis plan section. Also include the time window and region of interest over which the index will be computed.
- Example: We will compute the mean amplitude based on the above specified time window (50-250 ms) and electrodes (Fz, FCz, Cz). -->
+<!-- If any measurements are going to be combined into an index (or even a mean), what measures will you use and how will they be combined? Include either a formula or a precise description of your method. If you are using a more complicated statistical method to combine measures (e.g., factor analysis, z-standardization within conditions/participants), you can note that here but describe the exact method in the analysis plan section. Also include the time window and region of interest over which the index will be computed.
+
+Example: We will compute the mean amplitude based on the above specified time window (50-250 ms) and electrodes (Fz, FCz, Cz). -->
 
 Enter your response here.
 
@@ -227,121 +242,147 @@ Enter your response here.
 
 ## Computer screen
 <!-- Type (e.g., LCD, CRT), resolution, refresh rate. Example: LED screen, 1920 x 1080 resolution, 59 Hz refresh rate.
-Distance between computer screen and participant, use of a chinrest or other constraints. Example: 1 m distance between screen and participant, no
-chinrest or constraints. -->
+
+Distance between computer screen and participant, use of a chinrest or other constraints. Example: 1 m distance between screen and participant, no chinrest or constraints. -->
 
 Enter your response here.
 
 
 ## EEG hardware and acquisition settings*
 <!-- Amplifier: manufacturer, model. Example: EEG activity will be recorded using a BioSemi Active-Two system (BioSemi, Inc., Netherlands).
- Electrode cap: manufacturer, model: Example: Brain Products (BrainVision) BrainCap.
- Electrodes:
- Do scalp electrodes have pre-amplifiers: Active (yes)/passive (no)
- Number and location of electrodes, including reference and ground,
-but excluding EOG and other non-EEG electrodes. Example: There will be 35 electrodes in total including two mastoid electrodes and a ground electrode at AFz. The remaining 32 electrodes are: F7, F8, FC5, FC6, T7, T8, CP5, CP6, P7, P8, FP1, FP2, AF3, AF4, FC1, FC2, F3, F4, C3, C4, CP1, CP2, P3, P4, PO3, PO4, Oz, Fz, Cz, Pz).
- Electrode material. Example: Ag/AgCl.
- Conductive medium. Example: Gel/dry/saline/adhesive paste
- Montage (e.g., standard 10‐5 system, custom). Example: we will use the standard 10-5 international electrode montage (Oostenveld & Praamstra, 2001).
- Online reference and ground electrode placement. Example: The BioSemi ActiveTwo system has two electrodes, the common mode sense (CMS) active electrode and the driven right leg (DRL) passive electrode, which will be used as reference and ground electrodes, respectively.
- Impedance level deemed acceptable for data collection or alternative data quality indicator for high input impedance amplifiers. Example: Electrode impedances on all recording sites will be kept below 5 kΩ at the beginning of data collection for all participants.
- Online sampling rate and filter settings (if applicable). Example: EEG activity will be recorded at a 1024 Hz sampling rate with a 100 Hz low-pass filter and a 0.16 Hz high-pass filter.
- Local power line frequency (usually 60 Hz in America and parts of Asia or 50 Hz in other parts of the world). Example: 50 Hz
- Describe other equipment in addition to EEG in as much detail as appropriate (e.g., ECG/EMG/EOG/eye tracking). (optional) -->
+
+Electrode cap: manufacturer, model: Example: Brain Products (BrainVision) BrainCap.
+
+Electrodes:
+
+Do scalp electrodes have pre-amplifiers: Active (yes)/passive (no)
+
+Number and location of electrodes, including reference and ground, but excluding EOG and other non-EEG electrodes. Example: There will be 35 electrodes in total including two mastoid electrodes and a ground electrode at AFz. The remaining 32 electrodes are: F7, F8, FC5, FC6, T7, T8, CP5, CP6, P7, P8, FP1, FP2, AF3, AF4, FC1, FC2, F3, F4, C3, C4, CP1, CP2, P3, P4, PO3, PO4, Oz, Fz, Cz, Pz).
+
+Electrode material. Example: Ag/AgCl.
+
+Conductive medium. Example: Gel/dry/saline/adhesive paste
+
+Montage (e.g., standard 10‐5 system, custom). Example: we will use the standard 10-5 international electrode montage (Oostenveld & Praamstra, 2001).
+
+Online reference and ground electrode placement. Example: The BioSemi ActiveTwo system has two electrodes, the common mode sense (CMS) active electrode and the driven right leg (DRL) passive electrode, which will be used as reference and ground electrodes, respectively.
+
+Impedance level deemed acceptable for data collection or alternative data quality indicator for high input impedance amplifiers. Example: Electrode impedances on all recording sites will be kept below 5 kΩ at the beginning of data collection for all participants.
+
+Online sampling rate and filter settings (if applicable). Example: EEG activity will be recorded at a 1024 Hz sampling rate with a 100 Hz low-pass filter and a 0.16 Hz high-pass filter.
+
+Local power line frequency (usually 60 Hz in America and parts of Asia or 50 Hz in other parts of the world). Example: 50 Hz
+
+Describe other equipment in addition to EEG in as much detail as appropriate (e.g., ECG/EMG/EOG/eye tracking). (optional) -->
 
 Enter your response here.
 
 
 # Pre-processing
 <!-- Please reorder these preprocessing steps to reflect the order you will apply them to your data. Please first read all questions in sections 22-30, which list a wide (but non-exhaustive) array of possible steps. Based on those suggestions, write an individualized pipeline about which steps you will take in which order. If you have already preprocessed the data before preregistering, you can still specify the steps you took, but please indicate that these steps have already been performed. For recommendations on the order of pre-processing steps, see Luck (2014).
+
 Please also clarify whether (some) preprocessing steps are common to all hypotheses or specific to only a sub-type of them. Furthermore, please specify whether different software is used at different stages of the preprocessing pipeline. -->
 
 
 ## General setup*
-<!-- List the order in which you will apply the preprocessing steps. Example:
-Resampling, re-referencing, offline-filtering, artifact correction/rejection,
-epoching, averaging, baseline correction
- Which program/toolbox/package are you going to use? For example,
-FieldTrip, EEGLAB, Brainstorm, or ERPLAB in MATLAB, or MNE in Python. Which version number? Example: All EEG data preprocessing steps will be scripted and run in MATLAB (v. 2021b) and the FieldTrip toolbox using the version that will be the latest at the time pre-processing begins.
-Will you use a pre-existing/standardized preprocessing pipeline (e.g., PREP, BEAPP, HAPPE; remember to also report the version number) or develop your own? Example: We will not use any pre-existing preprocessing pipelines. The planned preprocessing steps are described below. -->
+<!-- List the order in which you will apply the preprocessing steps.
+
+Example: Resampling, re-referencing, offline-filtering, artifact correction/rejection, epoching, averaging, baseline correction
+
+Which program/toolbox/package are you going to use? For example, FieldTrip, EEGLAB, Brainstorm, or ERPLAB in MATLAB, or MNE in Python. Which version number?
+
+Example: All EEG data preprocessing steps will be scripted and run in MATLAB (v. 2021b) and the FieldTrip toolbox using the version that will be the latest at the time pre-processing begins.
+
+Will you use a pre-existing/standardized preprocessing pipeline (e.g., PREP, BEAPP, HAPPE; remember to also report the version number) or develop your own?
+
+Example: We will not use any pre-existing preprocessing pipelines. The planned preprocessing steps are described below. -->
 
 Enter your response here.
 
 
 ## Data import*
-<!-- What software will be used to record the EEG data? Example: EEG data will
-be recorded using BrainVision Recorder software (the latest available version
-at the start of data collection).
- What file format will you use at recording? Are you planning to export the files
-to a different format for analyses (e.g., .edf, .cnt, .bnf)? Example: The data
-will be recorded in .eeg format and exported to .edf for analyses.
- Will you import all recorded channels or a subset? Example: All recorded
-channels will be imported. -->
+<!-- What software will be used to record the EEG data? Example: EEG data will be recorded using BrainVision Recorder software (the latest available version at the start of data collection).
+
+What file format will you use at recording? Are you planning to export the files to a different format for analyses (e.g., .edf, .cnt, .bnf)? Example: The data will be recorded in .eeg format and exported to .edf for analyses.
+
+Will you import all recorded channels or a subset? Example: All recorded channels will be imported. -->
 
 Enter your response here.
 
 
 ## Resampling*
-<!-- Are you going to resample the continuous EEG signal? If so, to what
-sampling rate? Example: The EEG data will be downsampled to 200 Hz to decrease file size and computational time. -->
+<!-- Are you going to resample the continuous EEG signal? If so, to what sampling rate? Example: The EEG data will be downsampled to 200 Hz to decrease file size and computational time. -->
 
 Enter your response here.
 
 
 ## Re-referencing*
 <!-- Are you going to re-reference your data?
+
 To what reference? Example: average reference, mean mastoids, Laplacian.
- Which channels are you going to re-reference? Example: all EEG channels will be re-referenced. -->
+
+Which channels are you going to re-reference? Example: all EEG channels will be re-referenced. -->
 
 Enter your response here.
 
 
 ## Offline filtering*
 <!-- Will filters be applied to continuous or epoched data?
- How will data be filtered (e.g., high-pass, low-pass, band-pass)? Please
-report at least the following properties:
-filter type, e.g., FIR, IIR, Butterworth
-filter order, e.g., 5th order
-filter cut-off type and frequency, e.g., 40 Hz ( −3 dB half-amplitude)
-filter roll-off, e.g., 12 dB/oct
+
+How will data be filtered (e.g., high-pass, low-pass, band-pass)? Please report at least the following properties:
+
+- filter type, e.g., FIR, IIR, Butterworth
+- filter order, e.g., 5th order
+- filter cut-off type and frequency, e.g., 40 Hz (−3 dB half-amplitude)
+- filter roll-off, e.g., 12 dB/oct
+
 Example: “[A] 5th order infinite impulse response (IIR) Butterworth filter [will be] used for low-pass filtering on the continuous (nonsegmented data), with a cut-off frequency (3 dB point) of 40 Hz and 12 dB/octave roll-off.” (Keil et al., 2014, p. 6). -->
 
 Enter your response here.
 
 
 ## Artifact rejection/correction*
-<!-- How are you going to identify noisy channels for subsequent interpolation
-(e.g., visually or using automated algorithms)? Example: EEG data will be inspected visually for flat channels which will be selected for interpolation. We will also use the FieldTrip semi-automatic ft_rejectvisual tool to identify noisy channels for interpolation.
- Will you use an interpolation algorithm for those bad channels? If so, what kind of algorithm will you use (e.g., spherical spline)? Example: Selected channels will be interpolated from 4 neighboring electrodes using the spherical spline method based on 3D sensor locations.
- Are you going to perform artifact rejection on continuous or epoched data? Example: Artifact rejection will be performed on continuous data.
- Are you going to do artifact rejection automatically, semi-automatically, manually, or not at all? Example: Artifact rejection will be performed automatically.
- If artifacts are rejected automatically or semi-automatically, what kind of artifact rejection algorithm will you use (e.g., z-value approach implemented in FieldTrip, detect abrupt spikes or flat activity based on kurtosis, reject epochs using spectral estimates)? What parameter values will you use for your algorithm? If artifacts are rejected manually, which criteria will you apply (e.g., only blinks and horizontal eye movements)?) Example: We will use the automatic artifact rejection algorithm implemented in Fieldtrip: we will reject from the analysis trials with a z-value > 3.
- What kind of artifact correction will you perform? For example, independent component analysis like FASTica as implemented in EEGLAB or Artifact Subspace Reconstruction (Mullen et al., 2013)? What parameter values will you use for your algorithm? Will you correct all artifacts (blinks, saccades, alpha, muscle, etc) or only a subset? For example, in infant research you might want to reject muscle artifacts from the neck but correct eye movement artifacts. Example: We will use AMICA algorithm (Palmer et al., 2012) (calculated data rank with 'pcakeep' option) for independent component analysis (ICA). The components corresponding to eye movements, blinks, heart activity will be identified and rejected semi-automatically with ICLabel (Pion-Tonachini et al., 2019): if a component is classified as eye movements or heart activity with > 60% and < 30% brain activity (and confirmed visually), then it will be rejected.
- More information: https://eeglab.org/tutorials/06_RejectArtifacts -->
+<!-- How are you going to identify noisy channels for subsequent interpolation (e.g., visually or using automated algorithms)? Example: EEG data will be inspected visually for flat channels which will be selected for interpolation. We will also use the FieldTrip semi-automatic ft_rejectvisual tool to identify noisy channels for interpolation.
+
+Will you use an interpolation algorithm for those bad channels? If so, what kind of algorithm will you use (e.g., spherical spline)? Example: Selected channels will be interpolated from 4 neighboring electrodes using the spherical spline method based on 3D sensor locations.
+
+Are you going to perform artifact rejection on continuous or epoched data? Example: Artifact rejection will be performed on continuous data.
+
+Are you going to do artifact rejection automatically, semi-automatically, manually, or not at all? Example: Artifact rejection will be performed automatically.
+
+If artifacts are rejected automatically or semi-automatically, what kind of artifact rejection algorithm will you use (e.g., z-value approach implemented in FieldTrip, detect abrupt spikes or flat activity based on kurtosis, reject epochs using spectral estimates)? What parameter values will you use for your algorithm? If artifacts are rejected manually, which criteria will you apply (e.g., only blinks and horizontal eye movements)?) Example: We will use the automatic artifact rejection algorithm implemented in Fieldtrip: we will reject from the analysis trials with a z-value > 3.
+
+What kind of artifact correction will you perform? For example, independent component analysis like FASTica as implemented in EEGLAB or Artifact Subspace Reconstruction (Mullen et al., 2013)? What parameter values will you use for your algorithm? Will you correct all artifacts (blinks, saccades, alpha, muscle, etc) or only a subset? For example, in infant research you might want to reject muscle artifacts from the neck but correct eye movement artifacts. Example: We will use AMICA algorithm (Palmer et al., 2012) (calculated data rank with 'pcakeep' option) for independent component analysis (ICA). The components corresponding to eye movements, blinks, heart activity will be identified and rejected semi-automatically with ICLabel (Pion-Tonachini et al., 2019): if a component is classified as eye movements or heart activity with > 60% and < 30% brain activity (and confirmed visually), then it will be rejected.
+
+More information: https://eeglab.org/tutorials/06_RejectArtifacts -->
 
 Enter your response here.
 
 
 ## Epoching and averaging*
-<!-- Are you going to epoch data? If so, what will the epoch length be? What part
-of the stimulus/response will epochs be time-locked to?
- Will you include a time window before the event of interest as a baseline?
+<!-- Are you going to epoch data? If so, what will the epoch length be? What part of the stimulus/response will epochs be time-locked to?
+
+Will you include a time window before the event of interest as a baseline?
+
 How long will it be and how did you come to this decision?
- How will these epochs be averaged to create ERPs? Include information
-about which stimuli and/or responses will be included in each average.
- Example: Epochs will be created starting 400 ms before the onset of the standard and deviant tones, and will last for 2400 ms. Standard and the two kinds of deviant tones (small or large difference) will be averaged separately
-per participant. -->
+
+How will these epochs be averaged to create ERPs? Include information about which stimuli and/or responses will be included in each average.
+
+Example: Epochs will be created starting 400 ms before the onset of the standard and deviant tones, and will last for 2400 ms. Standard and the two kinds of deviant tones (small or large difference) will be averaged separately per participant. -->
 
 Enter your response here.
 
 
 ## Baseline correction*
 <!-- Will you apply baseline correction?
- Over what time window? Example: 400 ms before the stimulus onset
-will be used for baseline correction.
+
+Over what time window? Example: 400 ms before the stimulus onset will be used for baseline correction.
+
 Will you calculate a separate baseline per trial, condition, block, participant? Example: the baseline will be extracted preceding stimulus onset for every trial
+
 What procedure will you use? Example: subtraction, division, covariate in statistical model
- More information: If you are recording other types of data or analyses in addition to ERPs (e.g., eye-tracking data), describe relevant software and pre-processing in as much detail as appropriate. -->
+
+More information: If you are recording other types of data or analyses in addition to ERPs (e.g., eye-tracking data), describe relevant software and pre-processing in as much detail as appropriate. -->
 
 Enter your response here.
 
@@ -351,56 +392,55 @@ Enter your response here.
 
 
 ## Statistical models*
-<!-- What statistical model will you use to test your hypotheses? Please include
-the type of model (e.g., ANOVA, cluster-based permutation test, linear mixed model, etc.) and the model specification (this includes each variable that will be included as predictors, outcomes, or covariates). Please specify any interactions, subgroup analyses, pairwise or complex contrasts, or follow-up tests from omnibus tests. Will you be using one- or two-tailed tests? If you are comparing multiple conditions or testing multiple hypotheses, how will you correct for multiple comparisons? Please also indicate which statistical model tests which hypothesis.
- Example: To analyze the EEG data, we will use a 2 x 2 mixed ANOVA on MMN mean amplitude values. Based on our main hypothesis, we will only consider whether the pitch difference x musical training interaction is statistically significant. We will not consider the main effects and therefore will not correct for multiple testing for several comparisons within the ANOVA. If the interaction (in either or both ANOVAs) is statistically significant, we will run post-hoc t-tests for the given ANOVA.
- More information: Please provide a specific recipe for analyzing the collected data. Ask yourself: did you provide enough detail so that someone else could run the same analysis again? -->
+<!-- What statistical model will you use to test your hypotheses? Please include the type of model (e.g., ANOVA, cluster-based permutation test, linear mixed model, etc.) and the model specification (this includes each variable that will be included as predictors, outcomes, or covariates). Please specify any interactions, subgroup analyses, pairwise or complex contrasts, or follow-up tests from omnibus tests. Will you be using one- or two-tailed tests? If you are comparing multiple conditions or testing multiple hypotheses, how will you correct for multiple comparisons? Please also indicate which statistical model tests which hypothesis.
+
+Example: To analyze the EEG data, we will use a 2 x 2 mixed ANOVA on MMN mean amplitude values. Based on our main hypothesis, we will only consider whether the pitch difference x musical training interaction is statistically significant. We will not consider the main effects and therefore will not correct for multiple testing for several comparisons within the ANOVA. If the interaction (in either or both ANOVAs) is statistically significant, we will run post-hoc t-tests for the given ANOVA.
+
+More information: Please provide a specific recipe for analyzing the collected data. Ask yourself: did you provide enough detail so that someone else could run the same analysis again? -->
 
 Enter your response here.
 
 
 ## Transformations
-<!-- If you plan on transforming, centering, or recoding the data, please describe
-that process here. Transformations often are not necessary for ERP data, but
-other factors in your model may need recoding (see example below).
- Example: We will compute the difference wave by subtracting the standard
-from the deviant waveform.
- More information: If any categorical predictors are included in a regression,
-indicate how those variables will be coded (e.g., dummy coding, summation coding, etc.) and what the reference category will be. -->
+<!-- If you plan on transforming, centering, or recoding the data, please describe that process here. Transformations often are not necessary for ERP data, but other factors in your model may need recoding (see example below).
+
+Example: We will compute the difference wave by subtracting the standard from the deviant waveform.
+
+More information: If any categorical predictors are included in a regression, indicate how those variables will be coded (e.g., dummy coding, summation coding, etc.) and what the reference category will be. -->
 
 Enter your response here.
 
 
 ## Inference criteria*
-<!-- What criteria will you use to make inferences (e.g., p-values, Bayes factors,
-specific model fit indices)? Where appropriate, please also report the cut-off
-criterion (e.g., p < .05, BF10 > 10).
- Example: We will use p <. 05 to determine statistical significance. -->
+<!-- What criteria will you use to make inferences (e.g., p-values, Bayes factors, specific model fit indices)? Where appropriate, please also report the cut-off criterion (e.g., p < .05, BF10 > 10).
+
+Example: We will use p <. 05 to determine statistical significance. -->
 
 Enter your response here.
 
 
 ## Data exclusion*
-<!-- How will you determine what data or samples, if any, to exclude from your
-analyses? How will outliers be handled? Will there be awareness checks? Is there a pre-specified minimum number of trials for participants to be retained in the final analysis? If so, how did you come to this decision (e.g., prior work indicates that 30 trials are required to elicit a reliable MMN)?
- Example: Participants will be excluded if there are less than 40 deviant trials per condition left after artifact rejection or due to technical failure; this cutoff is based on prior work by X et al. (2014). -->
+<!-- How will you determine what data or samples, if any, to exclude from your analyses? How will outliers be handled? Will there be awareness checks? Is there a pre-specified minimum number of trials for participants to be retained in the final analysis? If so, how did you come to this decision (e.g., prior work indicates that 30 trials are required to elicit a reliable MMN)?
+
+Example: Participants will be excluded if there are less than 40 deviant trials per condition left after artifact rejection or due to technical failure; this cutoff is based on prior work by X et al. (2014). -->
 
 Enter your response here.
 
 
 ## Missing data*
 <!-- How will you deal with incomplete or missing data?
- Example: Since we exclude all the data of participants that have less than
-our prespecified number of trials in any condition, we will have an average MMN value for each participant for each condition. Missing deviants due to noise will not be imputed.
- Example: In case of missing values in one or more conditions for a participant, we will employ Multiple imputation using Fully Conditional Specification (FCS) implemented by the MICE algorithm (Buuren & Groothuis-Oudshoorn, 2011), as implemented in the R package mice (Buuren & Groothuis-Oudshoorn, 2011). -->
+
+Example: Since we exclude all the data of participants that have less than our prespecified number of trials in any condition, we will have an average MMN value for each participant for each condition. Missing deviants due to noise will not be imputed.
+
+Example: In case of missing values in one or more conditions for a participant, we will employ Multiple imputation using Fully Conditional Specification (FCS) implemented by the MICE algorithm (Buuren & Groothuis-Oudshoorn, 2011), as implemented in the R package mice (Buuren & Groothuis-Oudshoorn, 2011). -->
 
 Enter your response here.
 
 
 ## Exploring your data
-<!-- You are obviously free to explore your data set to look for unexpected
-relationships. You may describe this procedure here. Describing this procedure here can serve as a reminder to meticulously log your analysis steps and decisions while performing your data exploration.
- Example: We will explore relationships between age and handedness and MMN amplitude. -->
+<!-- You are obviously free to explore your data set to look for unexpected relationships. You may describe this procedure here. Describing this procedure here can serve as a reminder to meticulously log your analysis steps and decisions while performing your data exploration.
+
+Example: We will explore relationships between age and handedness and MMN amplitude. -->
 
 Enter your response here.
 
@@ -413,11 +453,10 @@ Enter your response here.
 
 
 ## Supplementary materials (optional)
-<!-- Example: figures, templates/checklists such as eCOBIDAS (Pernet et al.,
-2020) or ARTEM-IS (Styles et al., 2021), preprocessing and analysis scripts
-(tested on pilot data)
- Data Management Plan: a document that specifies how data will be
-organized, tracked, stored, and eventually shared following the FAIR guiding principles of Findability, Accessibility, Interoperability, and Reusability, to facilitate result reproducibility. Your institution and/or funding body may already require it and you can consider adding a copy here as well. -->
+
+<!-- Example: figures, templates/checklists such as eCOBIDAS (Pernet et al., 2020) or ARTEM-IS (Styles et al., 2021), preprocessing and analysis scripts (tested on pilot data)
+
+Data Management Plan: a document that specifies how data will be organized, tracked, stored, and eventually shared following the FAIR guiding principles of Findability, Accessibility, Interoperability, and Reusability, to facilitate result reproducibility. Your institution and/or funding body may already require it and you can consider adding a copy here as well. -->
 
 Enter your response here.
 


### PR DESCRIPTION
Introduce automated formatting rules for comment blocks, including paragraph joining, blank-line separation, and leading-whitespace removal. Document these rules and provide guidance for manual adjustments regarding unlabeled bullet lists. Update relevant documentation to reflect these changes.